### PR TITLE
Fixed Issue with Volume Settings Resetting on Pause Menu

### DIFF
--- a/UnderTheMoonlight/Assets/Prefabs/GameManager.prefab
+++ b/UnderTheMoonlight/Assets/Prefabs/GameManager.prefab
@@ -45,4 +45,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   musicPlayerPrefab: {fileID: 4346713665042988380, guid: 2007988f687e4f444ba9455c1c93e5d1,
     type: 3}
+  volManager: {fileID: 11400000, guid: 44f82a4841cf05942a5d07804f24d9db, type: 2}
   firstLevelBuildIndex: 2

--- a/UnderTheMoonlight/Assets/Scripts/Managers/GameManager.cs
+++ b/UnderTheMoonlight/Assets/Scripts/Managers/GameManager.cs
@@ -7,7 +7,8 @@ namespace UnderTheMoonlight.Managers
     {
         public static GameManager Instance { get; private set; } = null;
 
-        [SerializeField] private GameObject musicPlayerPrefab = null; 
+        [SerializeField] private GameObject musicPlayerPrefab = null;
+        [SerializeField] private VolumeManager volManager = null;
 
         [Space]
 
@@ -64,6 +65,8 @@ namespace UnderTheMoonlight.Managers
         /// <summary> Loads the next levl in the build index. </summary>
         public void LoadNextLevel()
         {
+            volManager.Initalize();
+            
             levelIndex++;
             if (levelIndex < SceneManager.sceneCountInBuildSettings)
                 SceneManager.LoadScene(levelIndex);

--- a/UnderTheMoonlight/Assets/Scripts/Managers/VolumeManager.asset
+++ b/UnderTheMoonlight/Assets/Scripts/Managers/VolumeManager.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: VolumeManager
   m_EditorClassIdentifier: 
   audioMix: {fileID: 24100000, guid: f0190995f79b8624ea96ca628ff82613, type: 2}
-  volMaster: 0
-  volMusic: 0
+  volMaster: -6.46103
+  volMusic: -0.69496393
   volCharacters: 0
-  volEffects: 0
+  volEffects: -3.709167

--- a/UnderTheMoonlight/Assets/Scripts/Managers/VolumeManager.cs
+++ b/UnderTheMoonlight/Assets/Scripts/Managers/VolumeManager.cs
@@ -19,7 +19,7 @@ namespace UnderTheMoonlight.Managers
         [SerializeField] private float volMusic = 0f;
         [SerializeField] private float volCharacters = 0f;
         [SerializeField] private float volEffects = 0f;
-
+        
         /// <summary> Initalizes the volume settings. </summary>
         public void Initalize()
         {
@@ -28,7 +28,7 @@ namespace UnderTheMoonlight.Managers
             SetLevel(volMasterName, volMaster);
             SetLevel(volMusicName, volMusic);
             SetLevel(volCharactersName, volCharacters);
-            SetLevel(volMasterName, volMaster);
+            SetLevel(volEffectsName, volEffects);
         }
 
         /// <summary> Saves the volume settings if the game is not running on webGL. </summary>
@@ -64,17 +64,25 @@ namespace UnderTheMoonlight.Managers
         {
             //if (!audioMix.GetFloat(volumeName, out level))
             //Debug.LogWarning("The parameter " + volumeName + " is not known the audio mix " + audioMix.name + ". The ref float level will not be set.");
-
-            if (volumeName == volMasterName)
-                level = volMaster;
-            else if (volumeName == volMusicName)
-                level = volMusic;
-            else if (volumeName == volCharactersName)
-                level = volCharacters;
-            else if (volumeName == volEffectsName)
-                level = volEffects;
-            else
-                Debug.LogWarning("The parameter " + volumeName + " is not known the audio mix " + audioMix.name + ". \nref float level will not be set.");
+            
+            switch (volumeName)
+            {
+                case volMasterName:
+                    level = volMaster;
+                    break;
+                case volMusicName:
+                    level = volMusic;
+                    break;
+                case volCharactersName:
+                    level = volCharacters;
+                    break;
+                case volEffectsName:
+                    level = volEffects;
+                    break;
+                default:
+                    Debug.LogWarning("The parameter " + volumeName + " is not known the audio mix " + audioMix.name + ". \nref float level will not be set.");
+                    break;
+            }
 
 
             //Debug.Log(volumeName + " : " + level);
@@ -87,14 +95,21 @@ namespace UnderTheMoonlight.Managers
         {
             audioMix.SetFloat(volumeName, level);
 
-            if (volumeName == volMasterName)
-                volMaster = level;
-            else if (volumeName == volMusicName)
-                volMusic = level;
-            else if (volumeName == volCharactersName)
-                volCharacters = level;
-            else if (volumeName == volEffectsName)
-                volEffects = level;
+            switch (volumeName)
+            {
+                case volMasterName:
+                    volMaster = level;
+                    break;
+                case volMusicName:
+                    volMusic = level;
+                    break;
+                case volCharactersName:
+                    volCharacters = level;
+                    break;
+                case volEffectsName:
+                    volEffects = level;
+                    break;
+            }
         }
     }
 }

--- a/UnderTheMoonlight/Assets/Scripts/SaveSystem.cs
+++ b/UnderTheMoonlight/Assets/Scripts/SaveSystem.cs
@@ -10,7 +10,7 @@ namespace UnderTheMoonlight
 
         /// <summary> Saves game data to a binary file. </summary>
         /// <typeparam name="T"> Type of data being saved. </typeparam>
-        /// <param name="dataName"> The name of your project. This should ideally be the same for all save files for this game for convenience. </param>
+        /// <param name="projectName"> The name of your project. This should ideally be the same for all save files for this game for convenience. </param>
         /// <param name="dataName"> A name for the data. This is be apart of the path for saving it. Make sure it's unique. </param>
         /// <param name="data"> Data to be saved. </param>
         public static void SaveDataToBinary<T>(string projectName, string dataName, T data)
@@ -27,7 +27,7 @@ namespace UnderTheMoonlight
 
         /// <summary> Loads game data from a binary file. </summary>
         /// <typeparam name="T"> Type of data being loaded. </typeparam>
-        /// <param name="dataName"> The name of your project. This should ideally be the same for all save files for this game for convenience. </param>
+        /// <param name="projectName"> The name of your project. This should ideally be the same for all save files for this game for convenience. </param>
         /// <param name="dataName"> A name for the data. This should have been used when saving the data. </param>
         /// <returns> Returns the data if it exists. If it doesn't, returns the default of that type. </returns>
         public static T LoadDataFromBinary<T>(string projectName, string dataName)


### PR DESCRIPTION
Fixes Issue #7 Volume Settings Resetting on Pause Menu

Fixed the issue with the volume settings getting reset on when the pause menu was first opened. This was because the Get Levels was getting the default values versus from the saved file. To fix this, the game manager now calls initalize on volume manager scritable object when the load next level function is called. This makes sure that the vales from the file are loaded in before get levels is called.